### PR TITLE
refactor: add query builder interface for mocking

### DIFF
--- a/NWOpen.Net/INWOpenQueryBuilder.cs
+++ b/NWOpen.Net/INWOpenQueryBuilder.cs
@@ -1,0 +1,35 @@
+// This program has been developed by students from the bachelor Computer Science at Utrecht
+// University within the Software Project course.
+// 
+// © Copyright Utrecht University (Department of Information and Computing Sciences)
+
+using NWOpen.Net.Models;
+
+namespace NWOpen.Net;
+
+/// <summary>
+/// Fluent builder for NWOpen project queries.
+/// </summary>
+public interface INWOpenQueryBuilder
+{
+    INWOpenQueryBuilder WithOrganization(string organization);
+    INWOpenQueryBuilder WithTitle(string title, bool exact = false);
+    INWOpenQueryBuilder WithRole(string role);
+    INWOpenQueryBuilder WithMemberLastName(string lastName);
+    INWOpenQueryBuilder WithStartDateFrom(DateTime from);
+    INWOpenQueryBuilder WithStartDateUntil(DateTime until);
+    INWOpenQueryBuilder WithEndDateFrom(DateTime from);
+    INWOpenQueryBuilder WithEndDateUntil(DateTime until);
+
+    /// <summary>
+    /// How many results to return.
+    /// </summary>
+    INWOpenQueryBuilder WithNumberOfResults(int numberOfResults);
+    
+    List<string> BuildQueries();
+
+    /// <summary>
+    /// Execute the query.
+    /// </summary>
+    Task<NWOpenResult?> ExecuteAsync();
+}

--- a/NWOpen.Net/NWOpenQueryBuilder.cs
+++ b/NWOpen.Net/NWOpenQueryBuilder.cs
@@ -12,7 +12,7 @@ namespace NWOpen.Net;
 /// <summary>
 /// A builder class to create a query to search for projects.
 /// </summary>
-public class NwOpenQueryBuilder
+public class NWOpenQueryBuilder : INWOpenQueryBuilder
 {
     /// <summary>
     /// The number of results per page.
@@ -60,7 +60,7 @@ public class NwOpenQueryBuilder
     /// </summary>
     private string? _titleQuery;
 
-    internal NwOpenQueryBuilder(NWOpenService service)
+    internal NWOpenQueryBuilder(NWOpenService service)
     {
         _service = service;
     }
@@ -71,7 +71,7 @@ public class NwOpenQueryBuilder
     /// <param name="organization">The organization name to filter by.</param>
     /// <remarks> Can only be called once. </remarks>
     /// <exception cref="InvalidOperationException"> Organization can only be set once </exception>
-    public NwOpenQueryBuilder WithOrganization(string organization)
+    public INWOpenQueryBuilder WithOrganization(string organization)
     {
         if (_organizationQuery != null)
             throw new InvalidOperationException("Organization can only be set once");
@@ -85,7 +85,7 @@ public class NwOpenQueryBuilder
     /// <param name="title">The title to filter by.</param>
     /// <param name="exact">Whether the title should be an exact match.</param>
     /// <exception cref="InvalidOperationException"> Title can only be set once </exception>
-    public NwOpenQueryBuilder WithTitle(string title, bool exact = false)
+    public INWOpenQueryBuilder WithTitle(string title, bool exact = false)
     {
         if (_titleQuery != null)
             throw new InvalidOperationException("Title can only be set once");
@@ -99,7 +99,7 @@ public class NwOpenQueryBuilder
     /// </summary>
     /// <param name="role">The role to filter by.</param>
     /// <exception cref="InvalidOperationException"> Role can only be set once </exception>
-    public NwOpenQueryBuilder WithRole(string role)
+    public INWOpenQueryBuilder WithRole(string role)
     {
         if (_roleQuery != null)
             throw new InvalidOperationException("Role can only be set once");
@@ -112,7 +112,7 @@ public class NwOpenQueryBuilder
     /// </summary>
     /// <param name="lastName">The last name to filter by.</param>
     /// <exception cref="InvalidOperationException"> Last name can only be set once </exception>
-    public NwOpenQueryBuilder WithMemberLastName(string lastName)
+    public INWOpenQueryBuilder WithMemberLastName(string lastName)
     {
         if (_lastNameQuery != null)
             throw new InvalidOperationException("Last name can only be set once");
@@ -125,7 +125,7 @@ public class NwOpenQueryBuilder
     /// </summary>
     /// <param name="from">The start date beginning of the range.</param>
     /// <exception cref="InvalidOperationException"> Start date from can only be set once </exception>
-    public NwOpenQueryBuilder WithStartDateFrom(DateTime from)
+    public INWOpenQueryBuilder WithStartDateFrom(DateTime from)
     {
         if (_startDateFrom.HasValue)
             throw new InvalidOperationException("Start date from can only be set once");
@@ -138,7 +138,7 @@ public class NwOpenQueryBuilder
     /// </summary>
     /// <param name="until">The start date end of the range.</param>
     /// <exception cref="InvalidOperationException"> Start date until can only be set once </exception>
-    public NwOpenQueryBuilder WithStartDateUntil(DateTime until)
+    public INWOpenQueryBuilder WithStartDateUntil(DateTime until)
     {
         if (_startDateUntil.HasValue)
             throw new InvalidOperationException("Start date until can only be set once");
@@ -151,7 +151,7 @@ public class NwOpenQueryBuilder
     /// </summary>
     /// <param name="from">The end date beginning of the range.</param>
     /// <exception cref="InvalidOperationException"> End date from can only be set once </exception>
-    public NwOpenQueryBuilder WithEndDateFrom(DateTime from)
+    public INWOpenQueryBuilder WithEndDateFrom(DateTime from)
     {
         if (_endDateFrom.HasValue)
             throw new InvalidOperationException("End date from can only be set once");
@@ -164,7 +164,7 @@ public class NwOpenQueryBuilder
     /// </summary>
     /// <param name="until">The end date end of the range.</param>
     /// <exception cref="InvalidOperationException"> End date until can only be set once </exception>
-    public NwOpenQueryBuilder WithEndDateUntil(DateTime until)
+    public INWOpenQueryBuilder WithEndDateUntil(DateTime until)
     {
         if (_endDateUntil.HasValue)
             throw new InvalidOperationException("End date until can only be set once");
@@ -179,7 +179,7 @@ public class NwOpenQueryBuilder
     /// <remarks> Must be greater than 0. Can only be set once. </remarks>
     /// <exception cref="InvalidOperationException"> Number of results can only be set once </exception>
     /// <exception cref="ArgumentException"> Number of results must be greater than 0 </exception>
-    public NwOpenQueryBuilder WithNumberOfResults(int numberOfResults)
+    public INWOpenQueryBuilder WithNumberOfResults(int numberOfResults)
     {
         if (numberOfResults <= 0)
             throw new ArgumentException("Number of results must be greater than 0");

--- a/NWOpen.Net/Services/INWOpenService.cs
+++ b/NWOpen.Net/Services/INWOpenService.cs
@@ -7,9 +7,9 @@ using NWOpen.Net.Models;
 
 namespace NWOpen.Net.Services;
 
-internal interface INWOpenService
+public interface INWOpenService
 {
     Task<NWOpenResult?> PerformQueryAsync(string query);
     Task<Project?> GetProjectAsync(string projectId);
-    NwOpenQueryBuilder Query();
+    NWOpenQueryBuilder Query();
 }

--- a/NWOpen.Net/Services/NWOpenService.cs
+++ b/NWOpen.Net/Services/NWOpenService.cs
@@ -76,5 +76,5 @@ public class NWOpenService : INWOpenService
         }
     }
 
-    public NwOpenQueryBuilder Query() => new(this);
+    public NWOpenQueryBuilder Query() => new(this);
 }

--- a/NWOpen.Tests/NwOpenQueryBuilderTests.cs
+++ b/NWOpen.Tests/NwOpenQueryBuilderTests.cs
@@ -100,7 +100,7 @@ public class NwOpenQueryBuilderTests
                 Content = JsonContent.Create(organizationResult),
             });
 
-        NwOpenQueryBuilder queryBuilder = _nwOpenService
+        INWOpenQueryBuilder queryBuilder = _nwOpenService
             .Query()
             .WithTitle("Test")
             .WithNumberOfResults(1);
@@ -134,7 +134,7 @@ public class NwOpenQueryBuilderTests
                 Content = new StringContent("Not JSON"),
             });
 
-        NwOpenQueryBuilder queryBuilder = _nwOpenService
+        INWOpenQueryBuilder queryBuilder = _nwOpenService
             .Query()
             .WithTitle("Test")
             .WithNumberOfResults(1);
@@ -157,7 +157,7 @@ public class NwOpenQueryBuilderTests
             )
             .ThrowsAsync(new HttpRequestException("network gone"));
 
-        NwOpenQueryBuilder queryBuilder = _nwOpenService
+        INWOpenQueryBuilder queryBuilder = _nwOpenService
             .Query()
             .WithTitle("Test")
             .WithNumberOfResults(1);
@@ -171,14 +171,14 @@ public class NwOpenQueryBuilderTests
     [Fact]
     public void WithNumberOfResults_ShouldThrow_WhenZero()
     {
-        NwOpenQueryBuilder queryBuilder = _nwOpenService.Query();
+        NWOpenQueryBuilder queryBuilder = _nwOpenService.Query();
         Assert.Throws<ArgumentException>(() => queryBuilder.WithNumberOfResults(0));
     }
 
     [Fact]
     public void WithNumberOfResults_ShouldThrow_WhenCalledTwice()
     {
-        NwOpenQueryBuilder queryBuilder = _nwOpenService
+        INWOpenQueryBuilder queryBuilder = _nwOpenService
             .Query()
             .WithNumberOfResults(1);
 
@@ -188,7 +188,7 @@ public class NwOpenQueryBuilderTests
     [Fact]
     public void WithTitle_ShouldThrow_WhenCalledTwice()
     {
-        NwOpenQueryBuilder queryBuilder = _nwOpenService
+        INWOpenQueryBuilder queryBuilder = _nwOpenService
             .Query()
             .WithTitle("Test");
 
@@ -198,7 +198,7 @@ public class NwOpenQueryBuilderTests
     [Fact]
     public void BuildQueries_ShouldReturnExpectedString()
     {
-        NwOpenQueryBuilder queryBuilder = _nwOpenService
+        INWOpenQueryBuilder queryBuilder = _nwOpenService
             .Query()
             .WithOrganization("Test")
             .WithTitle("Test")


### PR DESCRIPTION
## YouTrack tasks
CX-208

## Description

This PR proposes to add an INWOpenQueryBuilder interface, so that we can mock the builder and tests it without making a real connection with the NWOpen Api.

## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Project builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Docs have been updated/created for altered/added code
- [x] Code is well-commented
